### PR TITLE
Add ability to define hci device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY . /app
 WORKDIR /app
 
 ENV RUUVI_DISCOVERY_ENV homeassistant
+ENV NOBLE_HCI_DEVICE_ID 1
 
 CMD [ "npm", "start" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,15 @@ RUN mkdir -p /app
 WORKDIR /app
 
 COPY ./package.json /app/package.json
+COPY ./run.sh /app/run.sh
 RUN npm install --no-audit --production
 
 COPY . /app
 WORKDIR /app
 
 ENV RUUVI_DISCOVERY_ENV homeassistant
-ENV NOBLE_HCI_DEVICE_ID 1
 
-CMD [ "npm", "start" ]
+CMD [ "./run.sh" ]
 
 # Build arguments
 ARG BUILD_ARCH

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
     "name": "RuuviTag Discovery",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "slug": "ruuvitag-discovery",
     "description": "Web interface to Discover RuuviTag Environmental Sensors and save measures to Home Assistant, MQTT, InfluxDB and Graphite",
     "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
@@ -16,6 +16,10 @@
     "ingress": true,
     "ingress_port": 8099,
     "panel_icon": "mdi:access-point",
-    "options": {},
-    "schema": false
+    "options": {
+        "hci_device_id": 1
+    },
+    "schema": {
+        "hci_device_id": "int"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruuvitag-discovery",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Discover RuuviTag Environmental Sensors using a web interface and broadcast measures to multiple targets (MQTT, InfluxDB, Graphite, Home Assistant).",
   "main": "index.js",
   "scripts": {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bashio
+set +u
+
+CONFIG_PATH=/data/options.json
+
+HCI_DEVICE_ID=$(jq --raw-output ".hci_device_id" $CONFIG_PATH)
+
+bashio::log.info "Start RuuviTag daemon"
+
+bashio::log.info "Using HCI_DEVICE_ID $HCI_DEVICE_ID"
+
+NOBLE_HCI_DEVICE_ID=$HCI_DEVICE_ID NODE_ENV=production node index.js


### PR DESCRIPTION
Now to the proper merge request. I have an external USB bluetooth dongle which I would like to use instead of built-in bluetooth module. 

This patch allows the user to define which HCI device is being used by RuuviTag discovery (though noble).

I'm happy to hear your thoughts and improvement suggestions.